### PR TITLE
Enable token-based AAI

### DIFF
--- a/apps/run_app.py
+++ b/apps/run_app.py
@@ -116,6 +116,7 @@ if use_aai and oidc is not None:
 	config.SECRET_KEY= 'SomethingNotEntirelySecret'
 	config.OIDC_CLIENT_SECRETS= secret_file
 	config.OIDC_OPENID_REALM= openid_realm
+	config.OIDC_TOKEN_TYPE_HINT = 'access_token'
 
 #if use_db and db is not None:
 if use_db and mongo is not None:

--- a/caesar_rest/__init__.py
+++ b/caesar_rest/__init__.py
@@ -11,15 +11,13 @@ __copyright__ = 'Copyright 2020 by Simone Riggi - INAF'
 import logging
 import logging.config
 
-
 # Create the Logger
 logging.basicConfig(format="%(asctime)-15s %(levelname)s - %(message)s",datefmt='%Y-%m-%d %H:%M:%S')
 logger= logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 logger.info("This is caesar_rest {0}-({1})".format(__version__, __date__))
 
-
-# Create celery 
+# Create celery
 from celery import Celery
 celery= Celery(
 	__name__,
@@ -29,7 +27,7 @@ celery= Celery(
 # Create OIDC (without connecting to app)
 oidc= None
 try:
-	from flask_oidc import OpenIDConnect
+	from flask_oidc_ex import OpenIDConnect
 	oidc = OpenIDConnect()
 except:
 	logger.warn("flask_oidc module not found, can't create OpenIDConnect(), no AAI will be used (hint: install flask_oidc)")

--- a/caesar_rest/app_route.py
+++ b/caesar_rest/app_route.py
@@ -27,8 +27,6 @@ from flask import send_file, send_from_directory, safe_join, abort, make_respons
 from werkzeug.utils import secure_filename
 from caesar_rest import oidc
 from caesar_rest.decorators import custom_require_login
-
-
 # Get logger
 logger = logging.getLogger(__name__)
 
@@ -41,7 +39,7 @@ app_describe_bp = Blueprint('app_describe', __name__,url_prefix='/caesar/api/v1.
 
 
 @app_names_bp.route('/apps',methods=['GET'])
-@custom_require_login
+@oidc.accept_token(require_token=True)
 def get_app_names():
 	""" Get supported apps """
 

--- a/caesar_rest/config.py
+++ b/caesar_rest/config.py
@@ -36,6 +36,8 @@ class Config(object):
 	OIDC_CLIENT_SECRETS = 'config/client_secrets.json'
 	OIDC_OPENID_REALM = 'neanias-development'
 	OIDC_SCOPES = ['openid', 'email', 'profile']
+#	OIDC_TOKEN_TYPE_HINT = 'access_token'
+#	OIDC_INTROSPECTION_AUTH_METHOD = 'client_secret_post'
 
 	# - MONG DB options
 	USE_MONGO = False

--- a/caesar_rest/decorators.py
+++ b/caesar_rest/decorators.py
@@ -4,30 +4,32 @@
 from functools import wraps
 from flask import current_app, request, g
 from caesar_rest import oidc
-
+import json
 # Get logger
 import logging
 logger = logging.getLogger(__name__)
 
-def custom_require_login(func):
+def custom_require_login(view_func, scopes_required=None, render_errors=True):
 	""" Decorator to require login only if AAI is enabled """
-
-	@wraps(func)
+	@wraps(view_func)
 	def decorated(*args, **kwargs):
 		aai_enabled= current_app.config['USE_AAI']
 		has_oidc= (oidc is not None)
-		logger.info("use_aai? %d has_oidc? %d" % (aai_enabled, has_oidc))
+		token = None
+		if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Bearer '):
+			token = request.headers['Authorization'].split(None,1)[1].strip()
+		if 'access_token' in request.form:
+			token = request.form['access_token']
+		elif 'access_token' in request.args:
+			token = request.args['access_token']
 
-		if aai_enabled and has_oidc:
-			if g.oidc_id_token is None:
-				logger.info("Calling OIDC login ...")
-				#return oidc.require_login(func(*args, **kwargs))
-				#return oidc.require_login(func)
-				#return oidc.redirect_to_auth_server(func, request.values)
-				return oidc.redirect_to_auth_server(request.url)
-			else:
-				return func(*args, **kwargs)
-		else:		
-			return func(*args, **kwargs)
-
+		validity = oidc.validate_token(token, scopes_required) # no scopes required
+		if (validity is True) or (not aai_enabled or not has_oidc):
+			return view_func(*args, **kwargs)
+		else:
+			response_body = {'error': 'invalid_token',
+                                     'error_description': validity}
+			if render_errors:
+				response_body = json.dumps(response_body)
+			return response_body, 401, {'WWW-Authenticate': 'Bearer'}
 	return decorated

--- a/caesar_rest/job_configurator.py
+++ b/caesar_rest/job_configurator.py
@@ -15,7 +15,7 @@ import ast
 import yaml
 
 # Import flask modules
-from flask import current_app
+from flask import current_app, g
 
 # Import caesare rest momdules
 from caesar_rest import oidc
@@ -533,11 +533,10 @@ class SFinderConfigurator(AppConfigurator):
 		use_mongo= (mongo_enabled and has_mongo)
 
 		# - Get aai info
-		aai_enabled= current_app.config['USE_AAI']
-		has_oidc= (oidc is not None)
 		username= 'anonymous'
-		if aai_enabled and has_oidc:
-			username= oidc.user_getfield('preferred_username')
+		if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+			username=g.oidc_token_info['email']
+		logger.warn(username)
 
 		# - Inspect inputfile (expect it is a uuid, so convert to filename)
 		logger.info("Finding inputfile uuid %s ..." % file_uuid)
@@ -604,11 +603,10 @@ class SFinderNNConfigurator(AppConfigurator):
 		use_mongo= (mongo_enabled and has_mongo)
 
 		# - Get aai info
-		aai_enabled= current_app.config['USE_AAI']
-		has_oidc= (oidc is not None)
 		username= 'anonymous'
-		if aai_enabled and has_oidc:
-			username= oidc.user_getfield('preferred_username')
+		if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+			username=g.oidc_token_info['email']
+		logger.warn(username)
 
 		# - Inspect inputfile (expect it is a uuid, so convert to filename)
 		logger.info("Finding inputfile uuid %s ..." % file_uuid)

--- a/caesar_rest/job_route.py
+++ b/caesar_rest/job_route.py
@@ -22,7 +22,7 @@ except ImportError:
 	from urllib2 import urlopen
 
 # Import flask modules
-from flask import current_app, Blueprint, render_template, request, redirect, url_for, flash
+from flask import current_app, Blueprint, render_template, request, redirect, url_for, flash, g
 from flask import send_file, send_from_directory, safe_join, abort, make_response, jsonify
 from werkzeug.utils import secure_filename
 
@@ -67,11 +67,10 @@ def submit_job():
 	res['submit_date']= ''
 
 	# - Get aai info
-	aai_enabled= current_app.config['USE_AAI']
-	has_oidc= (oidc is not None)
 	username= 'anonymous'
-	if aai_enabled and has_oidc:
-		username= oidc.user_getfield('preferred_username')
+	if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+		username=g.oidc_token_info['email']
+	logger.warn(username) 
 
 	# - Get mongo info
 	mongo_enabled= current_app.config['USE_MONGO']
@@ -177,11 +176,10 @@ def get_job_ids():
 	""" Retrieve all job ids per user """
 
 	# - Get aai info
-	aai_enabled= current_app.config['USE_AAI']
-	has_oidc= (oidc is not None)
 	username= 'anonymous'
-	if aai_enabled and has_oidc:
-		username= oidc.user_getfield('preferred_username')
+	if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+		username=g.oidc_token_info['email']
+	logger.warn(username) 
 
 	# - Get mongo info
 	mongo_enabled= current_app.config['USE_MONGO']
@@ -315,11 +313,10 @@ def get_job_status(task_id):
 	res['elapsed_time']= ''
 
 	# - Get aai info
-	aai_enabled= current_app.config['USE_AAI']
-	has_oidc= (oidc is not None)
 	username= 'anonymous'
-	if aai_enabled and has_oidc:
-		username= oidc.user_getfield('preferred_username')
+	if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+		username=g.oidc_token_info['email']
+	logger.warn(username)
 
 	# - Get mongo info
 	mongo_enabled= current_app.config['USE_MONGO']
@@ -362,11 +359,10 @@ def get_job_output(task_id):
 	res['status']= ''
 
 	# - Get aai info
-	aai_enabled= current_app.config['USE_AAI']
-	has_oidc= (oidc is not None)
 	username= 'anonymous'
-	if aai_enabled and has_oidc:
-		username= oidc.user_getfield('preferred_username')
+	if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+		username=g.oidc_token_info['email']
+	logger.warn(username)
 
 	# - Check job status
 	try:

--- a/caesar_rest/upload_route.py
+++ b/caesar_rest/upload_route.py
@@ -22,7 +22,7 @@ except ImportError:
 	from urllib2 import urlopen
 
 # import Flask modules
-from flask import current_app, Blueprint, flash, request, redirect, render_template, url_for
+from flask import current_app, Blueprint, flash, request, redirect, render_template, url_for, g
 from flask import send_file, send_from_directory, safe_join, abort, make_response, jsonify
 #from flask_api import status
 from werkzeug.utils import secure_filename
@@ -55,12 +55,10 @@ def upload_file():
 	logger.info("request.url=%s" % request.url)
 
 	# - Get aai info
-	aai_enabled= current_app.config['USE_AAI']
-	has_oidc= (oidc is not None)
 	username= 'anonymous'
-	if aai_enabled and has_oidc:
-		username= oidc.user_getfield('preferred_username')	
-
+	if ('oidc_token_info' in g) and (g.oidc_token_info is not None and 'email' in g.oidc_token_info):
+		username=g.oidc_token_info['email']
+	logger.warn(username) 
 	# - Get mongo info
 	mongo_enabled= current_app.config['USE_MONGO']
 	has_mongo= (mongo is not None)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ reqs.append('pyyaml')
 
 #reqs.append('flask-mongoengine')
 reqs.append('flask-pymongo')
-
+reqs.append('flask_oidc_ex')
 #data_dir = 'data'
 
 setup(


### PR DESCRIPTION
Implemented changes required to use token-based AAI in Neanias:
- Added flask_oidc_ex dependency; import changed. This is needed for local validation of jwt tokens.
- Added OIDC configuration parameter OIDC_TOKEN_TYPE_HINT = 'access_token'. 
- Custom decorator changed to mimic the OIDC "accept_token" behaviour if aai enabled. We need to think a better way to do this.
- Now the current user is grabbed from the global variable g.oidc_token_info (automatically populated when a request with the proper header arrives).