### PR TITLE
feat: provide more info on fileids and jobs endpoints, store tags in mongoDB

### DIFF
--- a/caesar_rest/download_route.py
+++ b/caesar_rest/download_route.py
@@ -57,16 +57,12 @@ def get_registered_file_ids():
 	use_mongo= (mongo_enabled and has_mongo)
 
 	# - Get all file uuids
-	d= {}	
+	d= {}
 	collection_name= username + '.files'
 	if use_mongo:
-		#data_collection= mongo.db[username]
 		data_collection= mongo.db[collection_name]
-		#file_ids= data_collection.find().distinct('_id')
-		file_ids= data_collection.find().distinct('fileid')
-		file_id_list= [str(fileid) for fileid in file_ids]
-		d.update({'file_ids':file_id_list})
-
+		file_cursor= data_collection.find({},projection={"_id":0, "filepath":0})
+		d = list(file_cursor)
 	else:
 		file_ids= current_app.config['datamgr'].get_file_ids()		
 		d.update({'file_ids':file_ids})

--- a/caesar_rest/job_route.py
+++ b/caesar_rest/job_route.py
@@ -190,10 +190,8 @@ def get_job_ids():
 	collection_name= username + '.jobs'
 	if use_mongo:
 		job_collection= mongo.db[collection_name]
-		job_ids= job_collection.find().distinct('job_id')
-		job_id_list= [str(jobid) for jobid in job_ids]
-		d.update({'job_ids':job_id_list})
-
+		job_cursor= job_collection.find({},projection={"_id":0})
+		d = list(job_cursor)
 	else:
 		d['status']= 'Server is running without MongoDB backend, so this functionality is not supported'
 		d['job_ids']= []

--- a/caesar_rest/upload_route.py
+++ b/caesar_rest/upload_route.py
@@ -66,6 +66,7 @@ def upload_file():
 	# - Init response
 	res= {
 		'filename_orig': '',
+		'tag': '',
 		'format': '',
 		'size': '',
 		'uuid': '',
@@ -110,7 +111,9 @@ def upload_file():
 	filename_dest= '.'.join([file_uuid,file_ext])
 	filename_dest_dir= current_app.config['UPLOAD_FOLDER'] + '/' + str(username)
 	#filename_dest_fullpath= os.path.join(current_app.config['UPLOAD_FOLDER'], filename_dest)
-	filename_dest_fullpath= os.path.join(filename_dest_dir, filename_dest)	
+	filename_dest_fullpath= os.path.join(filename_dest_dir, filename_dest)
+	
+	file_tag = request.form['tag']
 
 	# - Create username directory if not existing before
 	try: 
@@ -133,6 +136,7 @@ def upload_file():
 	file_size= os.path.getsize(filename_dest_fullpath)/(1024.*1024.) # in MB
 
 	res['filename_orig']= filename
+	res['tag'] = file_tag
 	res['format']= file_ext
 	res['size']= file_size
 	res['uuid']= file_uuid
@@ -165,11 +169,12 @@ def upload_file():
 		data_fileobj= {
 			"filepath": filename_dest_fullpath,
 			"fileid": file_uuid,
+			"filename_orig": filename,
 			"fileext": file_ext,	
 			"filesize": file_size,
 			"filedate": file_upload_date, 
 			"metadata": '', # FIX ME
-			"tag": ''	# FIX ME
+			"tag": file_tag
 		}
 
 		collection_name= username + '.files'


### PR DESCRIPTION
Implemented "tag" feature when uploading files, stored in MongoDB.

Changes to provide additional information in /jobs and /fileids endpoints
- creation/submission date
- original filename
- tag